### PR TITLE
Don't restart supervisor in handler when state is not set to "started".

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Set up the latest or a specific version of supervisor in Ubuntu systems.
 #### Variables
 
 * `supervisor_version` [default: `latest`]: Supervisor version to install (e.g. `latest`, `3.1.3`)
-
+* `supervisor_state` [default: `started`]: Describes the desired state
+  for the supervisor service to be in.
 * `supervisor_unix_http_server_file` [default: `/var/run/supervisor.sock`]: A path to a UNIX domain socket (e.g. /tmp/supervisord.sock) on which supervisor will listen for HTTP/XML-RPC requests. `supervisorctl` uses XML-RPC to communicate with supervisord over this port
 * `supervisor_unix_http_server_chmod` [default: `'0700'`]: Change the UNIX permission mode bits of the UNIX domain socket to this value at startup
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # defaults file for supervisor
 ---
 supervisor_version: latest
-
+supervisor_state: started
 supervisor_unix_http_server_file: /var/run/supervisor.sock
 supervisor_unix_http_server_chmod: '0700'
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,4 @@
   service:
     name: supervisor
     state: restarted
+  when: supervisor_state is "started"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,4 +4,4 @@
   service:
     name: supervisor
     state: restarted
-  when: supervisor_state is "started"
+  when: supervisor_state == "started"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: start and enable service
   service:
     name: supervisor
-    state: started
+    state: "{{ supervisor_state }}"
     enabled: true
   tags:
     - configuration


### PR DESCRIPTION
Had a situation where there were numerous restarts happening because of files being modified and this is to prevent supervisor from being started until we explicitly want it running.
