### PR TITLE
fix supervisor restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
 - name: restart supervisor
   service:
     name: supervisor
-    state: restarted
+    state: restarted 
   when: supervisor_state == 'started'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,15 @@
     - supervisor
     - supervisor-groups
 
+- name: stop supervisor
+  service:
+    name: supervisor
+    state: stopped
+  tags:
+    - configuration
+    - supervisor
+    - supervisor-stop-service
+
 - name: start and enable service
   service:
     name: supervisor


### PR DESCRIPTION
restarting supervisor by relying on it's init script 'restart' parameter doesn't work on Debian correctly, resulting in a failure. The problem is not supervisor itself, but rather it's init scripts. A service stop followed by a service start is necessary. A bit more information at the following location:

http://stackoverflow.com/questions/32738415/supervisor-fails-to-restart-half-of-the-time

Typical error when doing a restart with supervisor already running:

```
[....] Restarting supervisor (via systemctl): supervisor.serviceJob for supervisor.service failed. See 'systemctl status supervisor.service' and 'journalctl -xn' for details.
 failed!
```
