### PR TITLE
Setup service for Debian systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Oefenweb/ansible-supervisor.svg?branch=master)](https://travis-ci.org/Oefenweb/ansible-supervisor) [![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-supervisor-blue.svg)](https://galaxy.ansible.com/tersmitten/supervisor)
 
-Set up the latest or a specific version of supervisor in Ubuntu and Debian-like (Jessie and up) systems.
+Set up the latest or a specific version of supervisor in Ubuntu and Debian (wheezy and up) systems.
 
 #### Requirements
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Oefenweb/ansible-supervisor.svg?branch=master)](https://travis-ci.org/Oefenweb/ansible-supervisor) [![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-supervisor-blue.svg)](https://galaxy.ansible.com/tersmitten/supervisor)
 
-Set up the latest or a specific version of supervisor in Ubuntu systems.
+Set up the latest or a specific version of supervisor in Ubuntu and Debian-like (Jessie and up) systems.
 
 #### Requirements
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,9 +26,16 @@ boxes = [
     :ram => "256"
   },
   {
+    :name => "debian-7",
+    :box => "bento/debian-7.11",
+    :ip => '10.0.0.14',
+    :cpu => "50",
+    :ram => "256"
+  },
+  {
     :name => "debian-8",
     :box => "bento/debian-8.7",
-    :ip => '10.0.0.14',
+    :ip => '10.0.0.15',
     :cpu => "50",
     :ram => "256"
   },

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,13 @@ boxes = [
     :cpu => "50",
     :ram => "256"
   },
+  {
+    :name => "debian-8",
+    :box => "bento/debian-8.7",
+    :ip => '10.0.0.14',
+    :cpu => "50",
+    :ram => "256"
+  },
 ]
 
 Vagrant.configure("2") do |config|

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,9 @@ galaxy_info:
         - precise
         - trusty
         - xenial
+    - name: Debian
+      versions:
+        - jessie
   galaxy_tags:
     - web
     - system

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
         - xenial
     - name: Debian
       versions:
+        - wheezy
         - jessie
   galaxy_tags:
     - web

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     - supervisor-configure
 
 - include: service-initd.yml
-  when: (ansible_os_family == 'Ubuntu' and (ansible_distribution_version | version_compare('15.04', '<')))
+  when: (ansible_distribution == 'Ubuntu' and (ansible_distribution_version | version_compare('15.04', '<')))
   tags:
     - configuration
     - supervisor
@@ -21,8 +21,8 @@
     - supervisor-configure-initd
 
 - include: service-systemd.yml
-  when: (ansible_os_family == 'Debian') or
-        (ansible_os_family == 'Ubuntu' and (ansible_distribution_version | version_compare('15.04', '>=')))
+  when: (ansible_distribution == 'Debian') or
+        (ansible_distribution == 'Ubuntu' and (ansible_distribution_version | version_compare('15.04', '>=')))
   tags:
     - configuration
     - supervisor

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     - supervisor-configure
 
 - include: service-initd.yml
-  when: (ansible_distribution == 'Ubuntu' and (ansible_distribution_version | version_compare('15.04', '<')))
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15.04', '<') or ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8.0', '<'))
   tags:
     - configuration
     - supervisor
@@ -21,8 +21,7 @@
     - supervisor-configure-initd
 
 - include: service-systemd.yml
-  when: (ansible_distribution == 'Debian') or
-        (ansible_distribution == 'Ubuntu' and (ansible_distribution_version | version_compare('15.04', '>=')))
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15.04', '>=') or ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8.0', '>='))
   tags:
     - configuration
     - supervisor

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     - supervisor-configure
 
 - include: service-initd.yml
-  when: ansible_distribution_version | version_compare('15.04', '<')
+  when: (ansible_os_family == 'Ubuntu' and (ansible_distribution_version | version_compare('15.04', '<')))
   tags:
     - configuration
     - supervisor
@@ -21,7 +21,8 @@
     - supervisor-configure-initd
 
 - include: service-systemd.yml
-  when: ansible_distribution_version | version_compare('15.04', '>=')
+  when: (ansible_os_family == 'Debian') or
+        (ansible_os_family == 'Ubuntu' and (ansible_distribution_version | version_compare('15.04', '>=')))
   tags:
     - configuration
     - supervisor


### PR DESCRIPTION
I have been using this patched version of the playbook for quite a while now on my Debian Jessie boxes and it works like a charm.

This only kind of adds support for Debian Jessie and newer, older versions still use init.d. 

