### PR TITLE
Add executable: "pip2" to pip module call.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,6 +14,7 @@
   pip:
     name: supervisor
     version: "{{ supervisor_version }}"
+    executable: "pip2"
   when: "supervisor_version != 'latest'"
   tags:
     - supervisor-install-specific
@@ -22,6 +23,7 @@
   pip:
     name: supervisor
     state: "{{ supervisor_version }}"
+    executable: "pip2"
   when: "supervisor_version == 'latest'"
   tags:
     - supervisor-install-latest


### PR DESCRIPTION
I tested this on ubuntu 16.04 with my installation script