### PR TITLE
autorestart default value as unexpected

### DIFF
--- a/templates/etc/supervisor/conf.d/program.conf.j2
+++ b/templates/etc/supervisor/conf.d/program.conf.j2
@@ -12,7 +12,7 @@ environment={{ item.value.environment }}
 autostart={{ item.value.autostart | default(false) | bool | to_json }}
 {% endif %}
 {% if item.value.autorestart is defined %}
-autorestart={{ item.value.autorestart | default(false) | bool | to_json}}
+autorestart={{ item.value.autorestart | default('unexpected')| to_json}}
 {% endif %}
 {% if item.value.startretries is defined %}
 startretries={{ item.value.startretries }}


### PR DESCRIPTION
`autorestart` should accept string values like default as: `unexpected` 
see: autorestart on http://supervisord.org/configuration.html#program-x-section-values