### PR TITLE
Allow the pip executable to be configured, as well as the dependencie…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,10 @@
 # defaults file for supervisor
 ---
+
+supervisor_dependencies:
+  - python
+supervisor_pip_executable: pip2
+
 supervisor_version: latest
 supervisor_unix_http_server_file: /var/run/supervisor.sock
 supervisor_unix_http_server_chmod: '0700'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,7 +14,7 @@
   pip:
     name: supervisor
     version: "{{ supervisor_version }}"
-    executable: pip2
+    executable: "{{ supervisor_pip_executable }}"
   when: "supervisor_version != 'latest'"
   tags:
     - supervisor-install-specific
@@ -23,7 +23,7 @@
   pip:
     name: supervisor
     state: "{{ supervisor_version }}"
-    executable: pip2
+    executable: "{{ supervisor_pip_executable }}"
   when: "supervisor_version == 'latest'"
   tags:
     - supervisor-install-latest

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,5 @@
 # vars file for supervisor
 ---
-supervisor_dependencies:
-  - python
+
 supervisor_install_prefix: /usr/local/bin
 supervisor_default_file: /etc/default/supervisor


### PR DESCRIPTION
Allow the pip executable to be configured, as well as the dependencies that are going to be installed. This allows pip3 and supervisor 4 to be used; and for installing python3 as a dependency.