### PR TITLE
Fixes deprecated with_items usage in apt module

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,11 +2,10 @@
 ---
 - name: install | dependencies
   apt:
-    name: "{{ item }}"
+    name: "{{ supervisor_dependencies }}"
     state: "{{ apt_install_state | default('latest') }}"
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
-  with_items: "{{ supervisor_dependencies }}"
   tags:
     - supervisor-install-dependencies
 


### PR DESCRIPTION
Fixing deprecation; Invoking apt only once while using a loop via squash_actions is deprecated.